### PR TITLE
Adding files for version 1.1.0

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -108,13 +108,28 @@ function atlantic_scripts() {
 	wp_enqueue_script('jquery-masonry');
 	wp_enqueue_script('atlantic-public-scripts', get_template_directory_uri() . '/js/front-end-scripts.js', array('jquery','jquery-masonry'));
 
-	if ( get_theme_mod('atlantic_font') ) :
+	//Universal Header & Body fonts
+	if ( get_theme_mod('atlantic_font') ){
 		wp_enqueue_style( 'atlantic-google-fonts-content', '//fonts.googleapis.com/css?family=' . get_theme_mod('atlantic_font') . '' );
-	endif;
-
-	if ( get_theme_mod('atlantic_heading_font') ) :
+	}
+	if ( get_theme_mod('atlantic_heading_font') ){
 		wp_enqueue_style( 'atlantic-google-fonts-heading', '//fonts.googleapis.com/css?family=' . get_theme_mod('atlantic_heading_font') . '' );
-	endif;
+	}
+	
+	//H specific fonts
+	$header_elements = array('h1','h2','h3','h4','h5','h6');
+	foreach($header_elements as $header){
+		
+		//custom font families set per header tag
+		$font_family = get_theme_mod('atlantic_' . $header .'_font_family');
+
+		if($font_family != 'default' || empty($font_family)){
+			$family = '//fonts.googleapis.com/css?family=' . $font_family; 
+			wp_enqueue_style( 'atlantic-google-fonts-header-' . $font_family . '-font', $family);
+		}
+		
+	}
+	
 
 	if ( get_theme_mod('atlantic_font') == '' && get_theme_mod('atlantic_heading_font') == '' ) :
 		wp_enqueue_style( 'atlantic-google-fonts', '//fonts.googleapis.com/css?family=Source+Code+Pro:400,900,200' );

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -114,11 +114,108 @@
 	wp.customize('atlantic_font_base_size', function( value ){
 		value.bind( function ( value ){
 			int_val = parseFloat(value);
-			html_rems = (62.5 * int_val) + '%';
+			html_rems = int_val + 'rem';
 			$('html').css('font-size', html_rems);
 		});
 		
 	});
+	
+	
+	//H1 - H6 settings 
+	var header_elements = {
+		'h1' : 'H1',
+		'.site-title' : 'Site Title',
+		'.site-description' : 'Site Description',
+		'h2' : 'H2',
+		'h3' : 'H3',
+		'h4' : 'H4',
+		'h5' : 'H5',
+		'h6' : 'H6',
+	}
+	
+	//go through each and find the elements we need and adjust them visually
+	$.each(header_elements, function(index, value){
+		
+			var key = index;
+
+			//font sizing adjustments
+			wp.customize('atlantic_' + key + '_font_size', function(value){	
+				value.bind('atlantic_' + key + '_color', function(value){
+		
+					value = parseFloat(value);
+					$headers = $(key); 
+					$headers.each(function(){
+						$(this).css('font-size', value  + 'rem');
+						
+					});
+				});	
+			});
+			
+			//font family adjustments
+			wp.customize('atlantic_' + key + '_font_family', function(value){			
+				value.bind('atlantic_' + key + '_color', function(value){
+		
+					$headers = $(key); 
+					$headers.each(function(){
+						$body = $('body');
+						$body.append("<link rel='stylesheet' href='http://fonts.googleapis.com/css?family=" + value +"' type='text/css' media='all' />");
+						$(this).css('font-family', value);
+						
+					});
+				});	
+			});
+			
+			
+			
+			//colour adjustments
+			wp.customize('atlantic_' + key + '_color', function( value ){
+				value.bind('atlantic_' + key + '_color', function( value ){
+					
+					$headers =  $(key); 
+					$headers.each(function(){
+						$(this).css('color', value);
+					});
+				});
+				
+			});
+			
+			//margin top adjustmnets
+			wp.customize('atlantic_' + key + '_margin_top', function( value ){
+				value.bind('atlantic_' + key + '_margin_top', function( value ){
+					
+					$headers =  $(key); 
+					$headers.each(function(){
+						$(this).css('margin-top', value + 'rem');
+					});
+				});
+				
+			});
+			
+			//margin bottom adjustmnets
+			wp.customize('atlantic_' + key + '_margin_bottom', function( value ){
+				value.bind('atlantic_' + key + '_margin_bottom', function( value ){
+					
+					$headers =  $(key); 
+					$headers.each(function(){
+						$(this).css('margin-bottom', value + 'rem');
+					});
+				});
+				
+			});
+		
+	});
+	
+	// header_elements.forEach(function(currentValue, index, array){
+// 		
+// 		
+// 		
+// 		
+	// });
+	
+	
+	
+	
+	
 	
 	
 } )( jQuery );

--- a/rtl.css
+++ b/rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://elevate360.com.au/atlantic-wordpress-theme/
 Author: Elevate
 Author URI: https://elevate360.com.au/
 Description: Atlantic
-Version: 1.0.3
+Version: 1.1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: atlantic


### PR DESCRIPTION
This revision is a major revision. Adding the following:

- All new customizer settings for H1,H2,H3,H4,H5,H6, site-title and site-description elements. Giving the user new control on how they render (such as individual font family selection, font sizes, font colors, margin top and margin bottom). 
- Adjustements for good fonts (all google fonts in drop downs are all separated in types e.g serif, handwriting etc)
- Populated default values for the customizer (will come back to later on)
- Additional small tweaks
