### PR TITLE
Fix missing WooCommerce return and load SVG icons

### DIFF
--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -12,11 +12,10 @@ function atlantic_include_svg_icons() {
 	// Define SVG sprite file.
 	$svg_icons = get_parent_theme_file_path( '/assets/images/svg-icons.svg' );
 
-	// If it exists, include it.
-	if ( file_exists( $svg_icons ) ) {
-		// require_once( $svg_icons );
-		get_template_part($svg_icons);
-	}
+       // If it exists, include it.
+       if ( file_exists( $svg_icons ) ) {
+               require_once $svg_icons;
+       }
 }
 add_action( 'wp_footer', 'atlantic_include_svg_icons', 9999 );
 

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -21,9 +21,11 @@ if ( ! function_exists( 'atlantic_is_woocommerce' ) ) :
  * @return [type] [description]
  */
 function atlantic_is_woocommerce(){
-	if ( function_exists( 'is_woocommerce' ) ) {
-		is_woocommerce();
-	}
+       if ( function_exists( 'is_woocommerce' ) ) {
+               return is_woocommerce();
+       }
+
+       return false;
 }
 endif;
 


### PR DESCRIPTION
## Summary
- load inline SVG icons correctly
- return result from WooCommerce page check

## Testing
- `npm install` *(fails: Python2 not found during node-sass build)*

------
https://chatgpt.com/codex/tasks/task_e_683fc03a9a00832da0a26f99aee3621a