### PR TITLE
Fix back compat file path

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,7 @@
  * Atlantic only works in WordPress 4.7 or later.
  */
 if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
-	require get_template_directory() . '/inc/back-compat.php';
+	require get_template_directory() . '/inc/back-compact.php';
 	return;
 }
 


### PR DESCRIPTION
## Summary
- correct the include path for the back compatibility file

## Testing
- `php -l functions.php`
- `php -l inc/back-compact.php`


------
https://chatgpt.com/codex/tasks/task_e_68411f100550832d8994247fd0153094