### PR TITLE
Add theme.json and update docs for WordPress 6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Atlantic
 
 **Contributors:** elevate360
-**Requires at least:** WordPress 4.7
-**Tested up to:** WordPress 4.8
-**Stable tag:** 1.2.1
-**Version:** 1.2.1
+**Requires at least:** WordPress 6.0
+**Tested up to:** WordPress 6.8
+**Stable tag:** 2.1.0
+**Version:** 2.1.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 **Tags:** one-column, two-columns, custom-background, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-width-template, footer-widgets, post-formats, sticky-post, theme-options, threaded-comments, translation-ready, blog, e-Commerce, photography

--- a/functions.php
+++ b/functions.php
@@ -8,9 +8,9 @@
  */
 
 /**
- * Atlantic only works in WordPress 4.7 or later.
+ * Atlantic only works in WordPress 6.0 or later.
  */
-if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], '6.0', '<' ) ) {
 	require get_template_directory() . '/inc/back-compact.php';
 	return;
 }

--- a/inc/back-compact.php
+++ b/inc/back-compact.php
@@ -2,9 +2,9 @@
 /**
  * Atlantic back compat functionality
  *
- * Prevents Atlantic from running on WordPress versions prior to 4.7,
+ * Prevents Atlantic from running on WordPress versions prior to 6.0,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.7.
+ * relies on many newer functions and markup changes introduced in 6.0.
  *
  * @package Atlantic
  */
@@ -27,33 +27,33 @@ add_action( 'after_switch_theme', 'atlantic_switch_theme' );
  * Adds a message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Atlantic on WordPress versions prior to 4.7.
+ * Atlantic on WordPress versions prior to 6.0.
  *
  * @since Atlantic 1.0.0
  *
  * @global string $wp_version WordPress version.
  */
 function atlantic_upgrade_notice() {
-	$message = sprintf( __( 'Atlantic requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] );
+       $message = sprintf( __( 'Atlantic requires at least WordPress version 6.0. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
 
 /**
- * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
+ * Prevents the Customizer from being loaded on WordPress versions prior to 6.0.
  *
  * @since Atlantic 1.0.0
  *
  * @global string $wp_version WordPress version.
  */
 function atlantic_customize() {
-	wp_die( sprintf( __( 'Atlantic requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] ), '', array(
+       wp_die( sprintf( __( 'Atlantic requires at least WordPress version 6.0. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] ), '', array(
 		'back_link' => true,
 	) );
 }
 add_action( 'load-customize.php', 'atlantic_customize' );
 
 /**
- * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 6.0.
  *
  * @since Atlantic 1.0.0
  *
@@ -61,7 +61,7 @@ add_action( 'load-customize.php', 'atlantic_customize' );
  */
 function atlantic_preview() {
 	if ( isset( $_GET['preview'] ) ) {
-		wp_die( sprintf( __( 'Atlantic requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] ) );
+               wp_die( sprintf( __( 'Atlantic requires at least WordPress version 6.0. You are running version %s. Please upgrade and try again.', 'atlantic' ), $GLOBALS['wp_version'] ) );
 	}
 }
 add_action( 'template_redirect', 'atlantic_preview' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atlantic",
-  "version": "1.2.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlantic",
   "title": "Atlantic",
-  "version": "1.2.1",
+  "version": "2.1.0",
   "private": true,
   "author": {
     "name": "Elevate360",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Atlantic ===
 
 Contributors: elevate360
-Requires at least: 4.7
-Tested up to: 4.8
-Stable tag: 1.2.1
-Version: 1.2.1
+Requires at least: 6.0
+Tested up to: 6.8
+Stable tag: 2.1.0
+Version: 2.1.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Tags: one-column, flexible-header, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, sticky-post, theme-options, threaded-comments, translation-ready, blog
@@ -28,6 +28,10 @@ The Atlantic Theme is built for small businesses looking to stand out. Atlantic 
 You can easily install and use Easy Google Fonts plugin.
 
 == Changelog ==
+
+= 2.1.0 - June 23, 2025 =
+* Added theme.json with block settings
+* Updated documentation and version numbers
 
 = 1.2.1 - December 19, 2017
 * Fixed texdomain

--- a/style.css
+++ b/style.css
@@ -4,8 +4,8 @@ Theme URI: https://cockatoo.com.au/themes/atlantic
 Author: Cockatoo
 Author URI: https://cockatoo.com.au/
 Description: Atlantic is for the creatives out there looking to give their creations the platform they deserve. Photographers, bloggers, videographers and artists alike will find Atlantic can not only mimic the style of their content but contribute to the design aesthetic you have in mind. Atlantic is a free high res photography blog theme for WordPress which understands the importance of presentation, offering a pixel perfect platform for your content. Atlantic serves as a digital frame for your photos. This theme compliments images that are large in scope, detailed in their display and ambitious in their composition. Each image is given its opportunity to shine unambiguously with Atlantic. This customizable theme can be changed to suit the individual style of each collection. Atlantic gives control to the user with domain over image and video sizes; selectable colours and fonts; as well as further customization opportunities with CSS.
-Version: 2.0.0
-Tested up to: 5.4
+Version: 2.1.0
+Tested up to: 6.8
 Requires PHP: 7.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "settings": {
+    "appearanceTools": true,
+    "color": {
+      "palette": [
+        { "name": "strong magenta", "slug": "strong-magenta", "color": "#a156b4" },
+        { "name": "light grayish magenta", "slug": "light-grayish-magenta", "color": "#d0a5db" },
+        { "name": "very light gray", "slug": "very-light-gray", "color": "#eee" },
+        { "name": "very dark gray", "slug": "very-dark-gray", "color": "#444" }
+      ],
+      "gradients": [
+        { "name": "Vivid cyan blue to vivid purple", "slug": "vivid-cyan-blue-to-vivid-purple", "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)" },
+        { "name": "Vivid green cyan to vivid cyan blue", "slug": "vivid-green-cyan-to-vivid-cyan-blue", "gradient": "linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)" },
+        { "name": "Light green cyan to vivid green cyan", "slug": "light-green-cyan-to-vivid-green-cyan", "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)" },
+        { "name": "Luminous vivid amber to luminous vivid orange", "slug": "luminous-vivid-amber-to-luminous-vivid-orange", "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)" },
+        { "name": "Luminous vivid orange to vivid red", "slug": "luminous-vivid-orange-to-vivid-red", "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)" }
+      ]
+    },
+    "typography": {
+      "fontSizes": [
+        { "name": "Small", "slug": "small", "size": "12px" },
+        { "name": "Regular", "slug": "regular", "size": "16px" },
+        { "name": "Large", "slug": "large", "size": "36px" },
+        { "name": "Huge", "slug": "huge", "size": "50px" }
+      ]
+    },
+    "layout": {
+      "contentSize": "540px",
+      "wideSize": "1110px"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `theme.json` file with palette, gradient and font size support
- bump version to 2.1.0 and update readmes
- require WordPress 6.0+ in back compat and functions
- note new version in changelog

## Testing
- `npm test` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c839e3f4832dae26739b4b7dd874