### PR TITLE
Switch to block templates

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"tagName":"footer","layout":{"type":"constrained"}} -->
+<footer class="wp-block-group">
+<!-- wp:paragraph -->
+<p>\u00a9 2025 Atlantic</p>
+<!-- /wp:paragraph -->
+</footer>
+<!-- /wp:group -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"tagName":"header","layout":{"type":"constrained"}} -->
+<header class="wp-block-group">
+<!-- wp:site-logo /-->
+<!-- wp:site-title /-->
+<!-- wp:navigation /-->
+</header>
+<!-- /wp:group -->

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+<main class="wp-block-group">
+<!-- wp:paragraph -->
+<p>Not Found</p>
+<!-- /wp:paragraph -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,19 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+<main class="wp-block-group">
+<!-- wp:query -->
+<!-- wp:post-template -->
+<!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template -->
+<!-- wp:query-pagination {"paginationArrow":"chevron"} -->
+<!-- wp:query-pagination-previous /-->
+<!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+<main class="wp-block-group">
+<!-- wp:post-title {"level":1} /-->
+<!-- wp:post-content /-->
+<!-- wp:comments /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -29,5 +29,19 @@
       "contentSize": "540px",
       "wideSize": "1110px"
     }
-  }
+  },
+  "templateParts": [
+    {
+      "name": "Header",
+      "slug": "header",
+      "area": "header",
+      "path": "block-template-parts/header.html"
+    },
+    {
+      "name": "Footer",
+      "slug": "footer",
+      "area": "footer",
+      "path": "block-template-parts/footer.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add `block-template-parts` directory with header/footer templates
- add new index, single, and 404 templates under `templates`
- enable template parts in `theme.json`

## Testing
- `npm test` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cf554348832d9b138c7858cde307