### PR TITLE
Add HTML template parts

### DIFF
--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 <?php wp_body_open(); ?>
 <div id="page" class="site">
 
-	<?php get_template_part( 'template-parts/skip', 'links' );?>
+       <?php block_template_part( 'skip-links' ); ?>
 
 	<header id="masthead" class="site-header">
 		<div class="container">

--- a/image.php
+++ b/image.php
@@ -17,9 +17,9 @@ get_header(); ?>
 
 					get_template_part( 'template-parts/content', 'image' );
 
-					if ( get_theme_mod( 'author_display', true ) == true ) {
-						get_template_part( 'template-parts/biography' );
-					}
+                                       if ( get_theme_mod( 'author_display', true ) == true ) {
+                                               block_template_part( 'biography' );
+                                       }
 				?>
 					<nav class="navigation post-navigation" role="navigation">
 						<div class="nav-links">

--- a/parts/biography.html
+++ b/parts/biography.html
@@ -1,0 +1,8 @@
+<!-- wp:group {"className":"author-info"} -->
+<div class="wp-block-group author-info">
+<!-- wp:heading {"level":2,"className":"about-author"} -->
+<h2 class="about-author">About The Author</h2>
+<!-- /wp:heading -->
+<!-- wp:post-author {"avatarSize":96,"showBio":true,"className":"author-detail"} /-->
+</div>
+<!-- /wp:group -->

--- a/parts/skip-links.html
+++ b/parts/skip-links.html
@@ -1,0 +1,3 @@
+<!-- wp:skip-link {"label":"Skip to navigation","target":"#site-navigation"} /-->
+<!-- wp:skip-link {"label":"Skip to content","target":"#content"} /-->
+<!-- wp:skip-link {"label":"Skip to Footer","target":"#secondary"} /-->

--- a/single.php
+++ b/single.php
@@ -17,9 +17,9 @@ get_header(); ?>
 
 			get_template_part( 'template-parts/content', get_post_type() );
 
-			if ( get_theme_mod( 'author_display', true ) == true ) {
-				get_template_part( 'template-parts/biography' );
-			}
+                       if ( get_theme_mod( 'author_display', true ) == true ) {
+                               block_template_part( 'biography' );
+                       }
 
 			the_post_navigation( array(
 			    'prev_text'                  => __( '<span>&larr; previous post</span> %title', 'atlantic' ),


### PR DESCRIPTION
## Summary
- use `block_template_part()` in PHP templates
- add new `biography.html` and `skip-links.html` block template parts

## Testing
- `npm test` *(fails: `grunt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cf744254832d96d2e60e3cdd0e88