### PR TITLE
Add block patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -236,6 +236,33 @@ endif;
 add_action( 'after_setup_theme', 'atlantic_setup' );
 
 /**
+ * Register custom block patterns located in the patterns folder.
+ */
+function atlantic_register_block_patterns() {
+       $patterns_dir = get_template_directory() . '/patterns';
+
+       if ( ! is_dir( $patterns_dir ) ) {
+               return;
+       }
+
+       foreach ( glob( $patterns_dir . '/*.{php,json}', GLOB_BRACE ) as $file ) {
+               $slug   = 'atlantic/' . basename( $file, '.' . pathinfo( $file, PATHINFO_EXTENSION ) );
+               $pattern = array();
+
+               if ( 'json' === pathinfo( $file, PATHINFO_EXTENSION ) ) {
+                       $pattern = json_decode( file_get_contents( $file ), true );
+               } else {
+                       $pattern = require $file;
+               }
+
+               if ( is_array( $pattern ) ) {
+                       register_block_pattern( $slug, $pattern );
+               }
+       }
+}
+add_action( 'init', 'atlantic_register_block_patterns' );
+
+/**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
  * Priority 0 to make it available to lower priority callbacks.

--- a/patterns/two-columns.php
+++ b/patterns/two-columns.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+    'title'       => __( 'Two Columns Text', 'atlantic' ),
+    'description' => _x( 'A simple two-column layout with headings and text.', 'Block pattern description', 'atlantic' ),
+    'categories'   => array( 'columns' ),
+    'viewportWidth'=> 960,
+    'content'      => '<!-- wp:columns --><div class="wp-block-columns"><!-- wp:column --><div class="wp-block-column"><!-- wp:heading --><h2>Left Heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Sample content in the left column.</p><!-- /wp:paragraph --></div><!-- /wp:column --><!-- wp:column --><div class="wp-block-column"><!-- wp:heading --><h2>Right Heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Sample content in the right column.</p><!-- /wp:paragraph --></div><!-- /wp:column --></div><!-- /wp:columns -->',
+);


### PR DESCRIPTION
## Summary
- register block patterns from a new `patterns` directory
- add an example two-column pattern

## Testing
- `npm test` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cf6a3a64832db41a108870487cac