### PR TITLE
Enable FSE layout options

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,0 +1,3 @@
+<!-- wp:group {"tagName":"footer"} -->
+<footer class="site-footer wp-block-group"></footer>
+<!-- /wp:group -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,0 +1,3 @@
+<!-- wp:group {"tagName":"header"} -->
+<header class="site-header wp-block-group"></header>
+<!-- /wp:group -->

--- a/functions.php
+++ b/functions.php
@@ -54,8 +54,8 @@ function atlantic_setup() {
 
 	set_post_thumbnail_size( 1140, 1140, false );
 
-	// Set the default content width.
-	$GLOBALS['content_width'] = 540;
+       // Set the default content width.
+       $GLOBALS['content_width'] = 800;
 
 	/*
 	 * Enable support for Post Formats.
@@ -246,9 +246,9 @@ function atlantic_content_width() {
 	$content_width = $GLOBALS['content_width'];
 
 	// Check if is single post and there is no sidebar.
-	if ( is_singular() ) {
-		$content_width = 1110;
-	}
+       if ( is_singular() ) {
+               $content_width = 1200;
+       }
 
 	/**
 	 * Filter Atlantic content width of the theme.

--- a/theme.json
+++ b/theme.json
@@ -26,8 +26,32 @@
       ]
     },
     "layout": {
-      "contentSize": "540px",
-      "wideSize": "1110px"
+      "contentSize": "800px",
+      "wideSize": "1200px"
+    },
+    "spacing": {
+      "units": [
+        "px",
+        "em",
+        "rem",
+        "%",
+        "vh",
+        "vw"
+      ]
     }
-  }
+  },
+  "templateParts": [
+    {
+      "name": "Header",
+      "slug": "header",
+      "area": "header",
+      "path": "block-template-parts/header.html"
+    },
+    {
+      "name": "Footer",
+      "slug": "footer",
+      "area": "footer",
+      "path": "block-template-parts/footer.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- update default content width in `functions.php`
- expand layout size options in `theme.json`
- add FSE spacing units and template parts

## Testing
- `npm test` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cf5fe3b0832db6b2453336580b3f