### PR TITLE
Add PHPUnit sample tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ nbproject
 node_modules
 dist
 orig
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Source: https://github.com/Automattic/genericons-neue
 **License:** GPL-2.0+
 Source: https://github.com/Automattic/social-logos
 
+## Running Tests
+
+This project includes a small PHPUnit test suite. After installing PHPUnit,
+run the tests from the theme root:
+
+```bash
+phpunit --configuration tests/phpunit.xml
+```
+
 ## Changelog
 
 ### 1.2.1 - December 19, 2017

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class UtilityTest extends TestCase {
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_get_min_suffix_returns_min_by_default() {
+        $this->assertSame('.min', atlantic_get_min_suffix());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_get_min_suffix_returns_empty_when_debug() {
+        define('SCRIPT_DEBUG', true);
+        $this->assertSame('', atlantic_get_min_suffix());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../inc/utility.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true" verbose="true">
+    <testsuites>
+        <testsuite name="Atlantic Test Suite">
+            <directory>./</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add a PHPUnit configuration and bootstrap under `tests/`
- add simple unit tests for `atlantic_get_min_suffix`
- update README with test instructions
- ignore PHPUnit result cache file

## Testing
- `phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68411ef7c728832d8e841cfdb3eba174