### PR TITLE
Fix theme panel comment

### DIFF
--- a/inc/customizer/settings.php
+++ b/inc/customizer/settings.php
@@ -14,7 +14,7 @@ function atlantic_customize_register( $wp_customize ) {
 
 	$setting = atlantic_setting_default();
 
-	// Arctic Theme Setting Panel
+	// Atlantic Theme Setting Panel
 	$wp_customize->add_panel( 'theme_settings', array(
 		'title' 		=> __( 'Theme Settings', 'atlantic' ),
 		'priority' 		=> 199,


### PR DESCRIPTION
## Summary
- fix comment in Customizer settings

## Testing
- `grep -n "Atlantic Theme Setting Panel" inc/customizer/settings.php`

------
https://chatgpt.com/codex/tasks/task_e_68411ef77004832daed10cf52dbf67c0