### PR TITLE
Fix textdomain spelling in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Source: https://github.com/Automattic/social-logos
 ## Changelog
 
 ### 1.2.1 - December 19, 2017
-* Fixed texdomain
+* Fixed textdomain
 * Updated `style.css`
 * Updated `readme.md` and `readme.txt`
 * Updated `package.json` and `gruntfile.js` for development

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ You can easily install and use Easy Google Fonts plugin.
 == Changelog ==
 
 = 1.2.1 - December 19, 2017
-* Fixed texdomain
+* Fixed textdomain
 * Updated `style.css`
 * Updated `readme.md` and `readme.txt`
 * Updated `package.json` and `gruntfile.js` for development


### PR DESCRIPTION
## Summary
- fix a typo in the changelog lines of `README.md` and `readme.txt`

## Testing
- `grep -n "textdomain" README.md readme.txt`

------
https://chatgpt.com/codex/tasks/task_e_68411ef5cefc832d943e60e218711187