### PR TITLE
Add hero and CTA block patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -217,18 +217,16 @@ function atlantic_setup() {
 		)
 	);
 
-	// register_block_pattern
-	register_block_pattern(
-		'wpdocs/my-example',
-		array(
-			'title'         => __( 'My First Block Pattern', 'atlantic' ),
-			'description'   => _x( 'This is my first block pattern', 'Block pattern description', 'atlantic' ),
-			'content'       => '<!-- wp:paragraph --><p>A single paragraph block style</p><!-- /wp:paragraph -->',
-			'categories'    => array( 'text' ),
-			'keywords'      => array( 'cta', 'demo', 'example' ),
-			'viewportWidth' => 800,
-		)
-	);
+        // Register theme block patterns.
+        register_block_pattern(
+                'atlantic/hero-banner',
+                require get_template_directory() . '/patterns/hero-banner.php'
+        );
+
+        register_block_pattern(
+                'atlantic/cta-block',
+                require get_template_directory() . '/patterns/cta-block.php'
+        );
 
 	add_theme_support( "responsive-embeds" );
 	add_theme_support( "align-wide" );

--- a/patterns/cta-block.php
+++ b/patterns/cta-block.php
@@ -1,0 +1,20 @@
+<?php
+return array(
+    'title'       => __( 'CTA Block', 'atlantic' ),
+    'description' => _x( 'Centered call to action section with heading and button.', 'Block pattern description', 'atlantic' ),
+    'categories'   => array( 'call-to-action' ),
+    'viewportWidth'=> 1200,
+    'content'      => '<!-- wp:group {"align":"full","backgroundColor":"very-light-gray","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}}} -->
+<div class="wp-block-group alignfull has-very-light-gray-background-color has-background" style="padding-top:60px;padding-bottom:60px"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="has-text-align-center">Call to Action</h2>
+<!-- /wp:heading -->
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Encourage visitors to take your desired action.</p>
+<!-- /wp:paragraph -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"strong-magenta","textColor":"very-light-gray"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-very-light-gray-color has-strong-magenta-background-color has-text-color has-background">Action Button</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->',
+);

--- a/patterns/hero-banner.php
+++ b/patterns/hero-banner.php
@@ -1,0 +1,20 @@
+<?php
+return array(
+    'title'       => __( 'Hero Banner', 'atlantic' ),
+    'description' => _x( 'Full width hero section with heading and button.', 'Block pattern description', 'atlantic' ),
+    'categories'   => array( 'featured', 'banner' ),
+    'viewportWidth'=> 1400,
+    'content'      => '<!-- wp:cover {"overlayColor":"strong-magenta","dimRatio":50,"minHeight":400,"align":"full"} -->
+<div class="wp-block-cover alignfull" style="min-height:400px"><span aria-hidden="true" class="wp-block-cover__background has-strong-magenta-background-color has-background-dim-50 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="has-text-align-center">Hero Title</h1>
+<!-- /wp:heading -->
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Add a short description or tagline here.</p>
+<!-- /wp:paragraph -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"very-dark-gray","textColor":"very-light-gray"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-very-light-gray-color has-very-dark-gray-background-color has-text-color has-background">Call to Action</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover -->',
+);


### PR DESCRIPTION
## Summary
- add a `hero-banner` block pattern for a simple hero section
- add a `cta-block` pattern for calls to action
- register new block patterns in `functions.php`

## Testing
- `npm test` *(fails: grunt not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593c014d04832d91dc06482a4921e3