### PR TITLE
Extend block support and theme settings

### DIFF
--- a/block-template-parts/hero.html
+++ b/block-template-parts/hero.html
@@ -1,0 +1,4 @@
+<!-- wp:cover {"overlayColor":"black","minHeight":300,"contentPosition":"center center"} -->
+<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim-50"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":1} --><h1 class="has-text-align-center">Welcome to Atlantic</h1><!-- /wp:heading --><!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">Add your intro text here.</p><!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->
+

--- a/functions.php
+++ b/functions.php
@@ -207,15 +207,33 @@ function atlantic_setup() {
 	add_theme_support( 'block-template-parts' );
 
 	// register_block_style 
-	register_block_style(
-		'core/quote',
-		array(
-			'name'         => 'blue-quote',
-			'label'        => __( 'Blue Quote', 'atlantic' ),
-			'is_default'   => true,
-			'inline_style' => '.wp-block-quote.is-style-blue-quote { color: blue; }',
-		)
-	);
+        register_block_style(
+                'core/quote',
+                array(
+                        'name'         => 'blue-quote',
+                        'label'        => __( 'Blue Quote', 'atlantic' ),
+                        'is_default'   => true,
+                        'inline_style' => '.wp-block-quote.is-style-blue-quote { color: blue; }',
+                )
+        );
+
+        register_block_style(
+                'core/button',
+                array(
+                        'name'         => 'outline-button',
+                        'label'        => __( 'Outline Button', 'atlantic' ),
+                        'inline_style' => '.wp-block-button.is-style-outline-button .wp-block-button__link{background:transparent;border:2px solid currentColor;}',
+                )
+        );
+
+        register_block_style(
+                'core/image',
+                array(
+                        'name'         => 'rounded',
+                        'label'        => __( 'Rounded', 'atlantic' ),
+                        'inline_style' => '.wp-block-image.is-style-rounded img{border-radius:10px;}',
+                )
+        );
 
 	// register_block_pattern
 	register_block_pattern(

--- a/patterns/hero-banner.php
+++ b/patterns/hero-banner.php
@@ -1,0 +1,9 @@
+<?php
+return array(
+    'title'       => __( 'Hero Banner', 'atlantic' ),
+    'description' => _x( 'A hero section with heading and call to action.', 'Block pattern description', 'atlantic' ),
+    'categories'   => array( 'featured' ),
+    'viewportWidth'=> 1200,
+    'content'      => '<!-- wp:cover {"overlayColor":"black","minHeight":320,"contentPosition":"center center"} -->
+<div class="wp-block-cover" style="min-height:320px"><span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim-50"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center"} --><h2 class="has-text-align-center">Hero Headline</h2><!-- /wp:heading --><!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">Intro text goes here.</p><!-- /wp:paragraph --><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} --><div class="wp-block-buttons"><!-- wp:button {"textColor":"very-light-gray","backgroundColor":"very-dark-gray"} --><div class="wp-block-button"><a class="wp-block-button__link has-very-light-gray-color has-very-dark-gray-background-color has-text-color has-background">Call to action</a></div><!-- /wp:button --></div><!-- /wp:buttons --></div></div><!-- /wp:cover -->',
+);

--- a/theme.json
+++ b/theme.json
@@ -23,6 +23,11 @@
           "name": "very dark gray",
           "slug": "very-dark-gray",
           "color": "#444"
+        },
+        {
+          "name": "Atlantic Blue",
+          "slug": "atlantic-blue",
+          "color": "#0033cc"
         }
       ],
       "gradients": [
@@ -113,6 +118,11 @@
           "fontFamily": "\"Lora\", serif",
           "slug": "lora",
           "name": "Lora"
+        },
+        {
+          "fontFamily": "\"Roboto\", sans-serif",
+          "slug": "roboto",
+          "name": "Roboto"
         }
       ],
       "fontSizes": [
@@ -165,6 +175,8 @@
         {"slug": "40", "size": "1.5rem", "name": "L"},
         {"slug": "50", "size": "2rem", "name": "XL"},
         {"slug": "60", "size": "3rem", "name": "XXL"}
+        ,
+        {"slug": "70", "size": "4rem", "name": "XXXL"}
       ],
       "units": [
         "px",
@@ -209,11 +221,17 @@
       "area": "header",
       "path": "block-template-parts/header.html"
     },
-    {
-      "name": "Footer",
-      "slug": "footer",
-      "area": "footer",
-      "path": "block-template-parts/footer.html"
-    }
-  ]
-}
+      {
+        "name": "Footer",
+        "slug": "footer",
+        "area": "footer",
+        "path": "block-template-parts/footer.html"
+      },
+      {
+        "name": "Hero Section",
+        "slug": "hero-section",
+        "area": "uncategorized",
+        "path": "block-template-parts/hero.html"
+      }
+    ]
+  }


### PR DESCRIPTION
## Summary
- register additional custom block styles
- add hero banner block pattern
- tweak global color palette, fonts, spacing
- register new hero template part

## Testing
- `npm test` *(fails: grunt not found)*
- `phpunit --configuration tests/phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593cf380c0832da057f5ff1f05588a